### PR TITLE
fix(rocm): avoid unmapped host-pointer dereference in Windows MoE offload

### DIFF
--- a/python/freetoken/engine/engine.py
+++ b/python/freetoken/engine/engine.py
@@ -12,7 +12,7 @@ from freetoken.core import Batch, Context, Req, set_global_ctx
 from freetoken.distributed import destroy_distributed, enable_pynccl_distributed, set_tp_info
 from freetoken.layers import set_rope_device
 from freetoken.models import create_model, load_weight
-from freetoken.moe import create_moe_backend, is_offload_moe_backend
+from freetoken.moe import create_moe_backend, decode_trace, is_offload_moe_backend
 from freetoken.moe.expert_banks import load_expert_banks
 from freetoken.moe.offload_cache import OffloadMoeCache, attach_offload_moe_cache
 from freetoken.utils import align_ceil, init_logger, is_sm90_family, is_sm100_family, mem_GB, torch_dtype
@@ -862,25 +862,39 @@ class Engine:
 
     def forward_batch(self, batch: Batch, args: BatchSamplingArgs) -> ForwardOutput:
         assert torch.cuda.current_stream() == self.stream
-        with self.ctx.forward_batch(batch):
-            if self.graph_runner.can_use_cuda_graph(batch):
-                logits = self.graph_runner.replay(batch)
-            else:
-                logits = self.model.forward()
-        if self.cpu_moe_executor is not None:
-            # One pinned read: surfaces a fired flag-handshake watchdog (dead coordinator
-            # -> stale expert outputs) as a loud error instead of silent corruption.
-            self.cpu_moe_executor.raise_if_unhealthy()
+        trace_started = decode_trace.begin_first_decode(batch)
+        failure: BaseException | None = None
+        try:
+            with self.ctx.forward_batch(batch):
+                if self.graph_runner.can_use_cuda_graph(batch):
+                    logits = self.graph_runner.replay(batch)
+                else:
+                    logits = self.model.forward()
+            if self.cpu_moe_executor is not None:
+                # One pinned read: surfaces a fired flag-handshake watchdog (dead coordinator
+                # -> stale expert outputs) as a loud error instead of silent corruption.
+                self.cpu_moe_executor.raise_if_unhealthy()
 
-        for req in batch.reqs:
-            req.complete_one()
+            for req in batch.reqs:
+                req.complete_one()
 
-        batch_logits = logits[: batch.size]
-        next_tokens_gpu = self.sampler.sample(batch_logits, args).to(torch.int32)
-        next_tokens_cpu = next_tokens_gpu.to("cpu", non_blocking=True)
-        copy_done_event = torch.cuda.Event()
-        copy_done_event.record(self.stream)
-        return ForwardOutput(next_tokens_gpu, next_tokens_cpu, copy_done_event)
+            batch_logits = logits[: batch.size]
+            if decode_trace.trace_active():
+                decode_trace.trace_stage("sampling_start")
+            next_tokens_gpu = self.sampler.sample(batch_logits, args).to(torch.int32)
+            if decode_trace.trace_active():
+                decode_trace.trace_stage("sampling_end")
+                decode_trace.synchronize("sampling", next_tokens_gpu.device)
+            next_tokens_cpu = next_tokens_gpu.to("cpu", non_blocking=True)
+            copy_done_event = torch.cuda.Event()
+            copy_done_event.record(self.stream)
+            return ForwardOutput(next_tokens_gpu, next_tokens_cpu, copy_done_event)
+        except BaseException as exc:
+            failure = exc
+            raise
+        finally:
+            if trace_started:
+                decode_trace.finish_trace(failed=failure)
 
     @torch.inference_mode()
     def _warmup_prefill(self) -> None:

--- a/python/freetoken/layers/moe.py
+++ b/python/freetoken/layers/moe.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Tuple
 import torch
 from freetoken.core import get_global_ctx
 from freetoken.distributed import DistributedCommunicator, get_tp_info
-from freetoken.moe import is_offload_moe_backend
+from freetoken.moe import decode_trace, is_offload_moe_backend
 from freetoken.moe.fused import fused_experts_decode_impl, fused_experts_impl, fused_topk
 from freetoken.moe.offload_cache import OffloadMoeCache
 from freetoken.utils import div_even
@@ -309,6 +309,8 @@ class OffloadMoELayer(MoELayer):
             return executor.decode(self.layer_id, hidden_states, topk_weights, topk_ids)
         if cache.decode_target == "hybrid":
             return self._decode_hybrid(cache, hidden_states, topk_weights, topk_ids)
+        if decode_trace.trace_active():
+            return self._decode_routed_traced(cache, hidden_states, topk_weights, topk_ids)
         cache.ensure_experts(self.layer_id, topk_ids)
         cache.copy_missing()
         return self._expert_gemm(
@@ -321,6 +323,133 @@ class OffloadMoELayer(MoELayer):
             alphas=cache.alphas_for_slots(self.layer_id),
             is_prefill=False,
         )
+
+    def _decode_routed_traced(
+        self,
+        cache: OffloadMoeCache,
+        hidden_states: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        """One-shot, synchronized diagnosis of the normal GPU offload decode path.
+
+        This method is unreachable unless ``FREETOKEN_ROCM_DECODE_TRACE`` claimed the
+        current real decode batch.  Keeping it separate leaves the normal CUDA/ROCm fast
+        path's launch order and tensor semantics unchanged.
+        """
+
+        raw_ids = decode_trace.snapshot_cpu(topk_ids)
+        active, hits, misses = decode_trace.cache_hit_miss_counts(
+            raw_ids,
+            cache.slot_for_id[self.layer_id],
+            cache.num_experts,
+        )
+        decode_trace.trace_stage(
+            "cache_counts",
+            layer=self.layer_id,
+            active_unique=active,
+            hit_count=hits,
+            miss_count=misses,
+        )
+
+        decode_trace.trace_stage("cache_ensure_experts_start", layer=self.layer_id)
+        cache.ensure_experts(self.layer_id, topk_ids)
+        decode_trace.trace_stage("cache_ensure_experts_completion", layer=self.layer_id)
+        decode_trace.synchronize("cache_ensure_experts", cache.device, layer=self.layer_id)
+
+        decode_trace.trace_tensor("remapped_slot_ids", topk_ids, include_minmax=True)
+        slot_min, slot_max, selected_slots = decode_trace.validate_remapped_slots(
+            raw_ids,
+            topk_ids,
+            cache.id_of_slot,
+            layer_id=self.layer_id,
+            num_experts=cache.num_experts,
+            num_cache_slots=cache.cache_size,
+        )
+        decode_trace.trace_stage(
+            "slot_bounds_valid",
+            layer=self.layer_id,
+            slot_min=slot_min,
+            slot_max=slot_max,
+            slot_count_bound=cache.cache_size,
+            selected_slot_count=selected_slots,
+        )
+        decode_trace.trace_stage(
+            "slot_population_valid",
+            layer=self.layer_id,
+            populated_route_count=topk_ids.numel(),
+            scheduled_copy_count=int(cache.num_indices.item()),
+        )
+
+        safe_copy_selected = cache.should_use_safe_offload_copy(self.layer_id)
+        decode_trace.preflight_windows_rocm_host_mapping(
+            cache,
+            self.layer_id,
+            allow_unmapped_safe_copy=safe_copy_selected,
+        )
+        decode_trace.trace_stage(
+            "copy_missing_start",
+            layer=self.layer_id,
+            copy_stream="current_compute_stream",
+            fused_copy=cache._copy_fused_ok,
+            safe_copy_selected=safe_copy_selected,
+        )
+        cache.copy_missing()
+        decode_trace.trace_stage("copy_missing_completion", layer=self.layer_id)
+        if not safe_copy_selected:
+            decode_trace.synchronize("copy_missing", cache.device, layer=self.layer_id)
+
+        decode_trace.trace_stage("expert_views_acquisition_start", layer=self.layer_id)
+        views = cache.bank_views()
+        for name, view in zip(cache.bank_schema, views):
+            if view.shape[0] != cache.cache_size:
+                raise ValueError(
+                    f"bank {name!r} has {view.shape[0]} slots, expected {cache.cache_size}"
+                )
+            decode_trace.trace_tensor(f"expert_bank_view_{name}", view)
+        decode_trace.trace_stage(
+            "expert_views_acquired",
+            layer=self.layer_id,
+            bank_count=len(views),
+            slot_count=cache.cache_size,
+        )
+        alphas = cache.alphas_for_slots(self.layer_id)
+        decode_trace.trace_stage(
+            "scale_alpha_views_acquired",
+            layer=self.layer_id,
+            alpha_view_count=0 if alphas is None else len(alphas),
+            quant_format=cache.quant_format,
+        )
+        if alphas is not None:
+            for index, alpha in enumerate(alphas):
+                if alpha.shape[0] != cache.cache_size:
+                    raise ValueError(
+                        f"alpha view {index} has {alpha.shape[0]} slots, "
+                        f"expected {cache.cache_size}"
+                    )
+                decode_trace.trace_tensor(f"alpha_view_{index}", alpha)
+        decode_trace.synchronize("expert_view_acquisition", cache.device, layer=self.layer_id)
+
+        decode_trace.trace_stage(
+            "expert_gemm_start",
+            layer=self.layer_id,
+            quant_format=cache.quant_format,
+        )
+        output = self._expert_gemm(
+            cache,
+            hidden_states,
+            topk_weights,
+            topk_ids,
+            views=views,
+            n=None,
+            alphas=alphas,
+            is_prefill=False,
+        )
+        decode_trace.trace_stage("expert_gemm_completion", layer=self.layer_id)
+        decode_trace.synchronize("expert_gemm", output.device, layer=self.layer_id)
+        decode_trace.trace_tensor("post_moe_reduction", output)
+        decode_trace.synchronize("post_moe_reduction", output.device, layer=self.layer_id)
+        return output
 
     def _decode_hybrid(
         self,

--- a/python/freetoken/models/gpt_oss/attention.py
+++ b/python/freetoken/models/gpt_oss/attention.py
@@ -8,6 +8,7 @@ from freetoken.distributed import get_tp_info
 from freetoken.layers import BaseOP, LinearOProj, LinearQKVMerged
 from freetoken.layers.rotary import get_rope
 from freetoken.models.config import FullAttentionGroupConfig, SWAAttentionGroupConfig
+from freetoken.moe import decode_trace
 from freetoken.utils import div_even, nvtx_annotate
 
 if TYPE_CHECKING:
@@ -66,6 +67,8 @@ class GptOssAttention(BaseOP):
     @nvtx_annotate("MHA")
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         ctx = get_global_ctx()
+        if decode_trace.trace_active():
+            decode_trace.trace_stage("attention_start", layer=self.layer_id)
         qkv = self.qkv_proj.forward(x)
         q, k, v = qkv.split(
             [self.qo_attn_dim, self.kv_attn_dim, self.kv_attn_dim],
@@ -87,7 +90,11 @@ class GptOssAttention(BaseOP):
                 sinks=self.sinks,
             ),
         )
-        return self.o_proj.forward(o.view(-1, self.qo_attn_dim))
+        output = self.o_proj.forward(o.view(-1, self.qo_attn_dim))
+        if decode_trace.trace_active():
+            decode_trace.trace_stage("attention_end", layer=self.layer_id)
+            decode_trace.synchronize("attention", output.device, layer=self.layer_id)
+        return output
 
 
 __all__ = ["GptOssAttention"]

--- a/python/freetoken/models/gpt_oss/model.py
+++ b/python/freetoken/models/gpt_oss/model.py
@@ -12,6 +12,7 @@ from freetoken.layers import (
     VocabParallelEmbedding,
 )
 from freetoken.models.blocks import BaseLLMModel
+from freetoken.moe import decode_trace
 from freetoken.utils import nvtx_annotate
 
 from .attention import GptOssAttention
@@ -86,7 +87,13 @@ class GptOssForCausalLM(BaseLLMModel):
 
     def forward(self) -> torch.Tensor:
         output = self.model.forward(get_global_ctx().batch.input_ids)
-        return self.lm_head.forward(output)
+        if decode_trace.trace_active():
+            decode_trace.trace_stage("logits_start")
+        logits = self.lm_head.forward(output)
+        if decode_trace.trace_active():
+            decode_trace.trace_stage("logits_end")
+            decode_trace.synchronize("logits", logits.device)
+        return logits
 
     def prepare_for_runtime(self) -> None:
         self.model.prepare_for_runtime()

--- a/python/freetoken/models/gpt_oss/moe.py
+++ b/python/freetoken/models/gpt_oss/moe.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import torch
 import freetoken.layers.moe as moe_layers
 from freetoken.layers import BaseOP, LinearReplicated, MoELayer, OffloadMoELayer
-from freetoken.moe import is_offload_moe_backend
+from freetoken.moe import decode_trace, is_offload_moe_backend
 from freetoken.moe.fused_mxfp4 import (
     MXFP4_DECODE_MAX_TOKENS,
     _transpose_mxfp4_for_decode,
@@ -186,7 +186,20 @@ class GptOssMxfp4OffloadMoELayer(OffloadMoELayer):
         assert router_logits is not None
         if not router_logits.is_contiguous():
             router_logits = router_logits.contiguous()
+        if decode_trace.trace_active():
+            decode_trace.trace_stage("routing_topk_start", layer=self.layer_id)
+            decode_trace.trace_tensor("routing_logits", router_logits)
         topk_weights, topk_ids = self._topk(router_logits)
+        if decode_trace.trace_active():
+            decode_trace.trace_stage("routing_topk_creation", layer=self.layer_id)
+            decode_trace.synchronize("routing_topk", topk_ids.device, layer=self.layer_id)
+            decode_trace.trace_tensor("routing_topk_weights", topk_weights)
+            decode_trace.trace_tensor("raw_expert_ids", topk_ids, include_minmax=True)
+            decode_trace.trace_stage("routing_id_clone_start", layer=self.layer_id)
+            routed_ids = topk_ids.clone()
+            decode_trace.trace_stage("routing_id_clone_completion", layer=self.layer_id)
+            decode_trace.synchronize("routing_id_clone", routed_ids.device, layer=self.layer_id)
+            return self.routed_forward(hidden_states, topk_weights, routed_ids)
         # routed_forward dispatches prefill/decode movement and all-reduces once;
         # topk_ids is cloned because decode rewrites it in place into slot ids.
         return self.routed_forward(hidden_states, topk_weights, topk_ids.clone())

--- a/python/freetoken/moe/decode_trace.py
+++ b/python/freetoken/moe/decode_trace.py
@@ -1,0 +1,469 @@
+"""Opt-in diagnostics for the first real autoregressive decode forward.
+
+The trace is deliberately process-local and one-shot.  It is claimed by
+``Engine.forward_batch`` only for a real ``Batch(phase="decode")``; startup prefill
+warmup therefore cannot consume it.  Normal execution pays only an environment
+check and an inactive-state branch.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, replace
+from typing import Any
+
+import torch
+
+
+TRACE_ENV = "FREETOKEN_ROCM_DECODE_TRACE"
+TRACE_PREFIX = "FT_ROCM_DECODE_TRACE"
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+@dataclass
+class _TraceState:
+    claimed: bool = False
+    active: bool = False
+    sequence: int = 0
+
+
+_state = _TraceState()
+
+
+@dataclass(frozen=True)
+class _HostMappingStatus:
+    safe_for_gpu_deref: bool
+    pinned_extension_loaded: bool
+    host_bank_residency: str
+    bank_count: int
+    mapped_bank_count: int
+    host_ptr: str
+    device_ptr: str
+    failed_bank: str
+    reason: str
+
+
+def trace_enabled() -> bool:
+    return os.getenv(TRACE_ENV, "").strip().lower() in _TRUE_VALUES
+
+
+def trace_active() -> bool:
+    return _state.active
+
+
+def _render(value: Any) -> str:
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (tuple, list)):
+        return "[" + ",".join(_render(item) for item in value) + "]"
+    text = str(value)
+    return repr(text) if any(ch.isspace() for ch in text) else text
+
+
+def trace_stage(stage: str, /, **fields: Any) -> None:
+    """Emit one stable, flush-on-write marker while the first-decode trace is active."""
+
+    if not _state.active:
+        return
+    _state.sequence += 1
+    parts = [TRACE_PREFIX, f"seq={_state.sequence}", f"stage={stage}"]
+    parts.extend(f"{key}={_render(fields[key])}" for key in sorted(fields))
+    print(" ".join(parts), file=sys.stderr, flush=True)
+
+
+def _stream_fields(device: torch.device | str | None = None) -> dict[str, Any]:
+    try:
+        if not torch.cuda.is_available():
+            return {"stream": "unavailable"}
+        stream = torch.cuda.current_stream(device)
+        return {
+            "stream": int(stream.cuda_stream),
+            "stream_device": str(stream.device),
+        }
+    except Exception as exc:  # diagnostics must not mask the stage being diagnosed
+        return {"stream": f"unavailable:{type(exc).__name__}"}
+
+
+def begin_first_decode(batch: Any) -> bool:
+    """Claim and begin the first real decode batch in this process, if requested."""
+
+    if _state.claimed or not trace_enabled() or not bool(getattr(batch, "is_decode", False)):
+        return False
+    _state.claimed = True
+    _state.active = True
+    batch_size = getattr(batch, "size", None)
+    fields: dict[str, Any] = {
+        "batch_size": batch_size if batch_size is not None else "unknown",
+        "phase": getattr(batch, "phase", "unknown"),
+    }
+    fields.update(_stream_fields())
+    trace_stage("decode_entry", **fields)
+    input_ids = getattr(batch, "input_ids", None)
+    if isinstance(input_ids, torch.Tensor):
+        trace_tensor("decode_input_ids", input_ids, include_minmax=True)
+    return True
+
+
+def finish_trace(*, failed: BaseException | None = None) -> None:
+    if not _state.active:
+        return
+    if failed is None:
+        trace_stage("decode_trace_complete")
+    else:
+        trace_stage(
+            "decode_trace_failed",
+            error_type=type(failed).__name__,
+            error=str(failed),
+        )
+    _state.active = False
+
+
+def synchronize(stage: str, device: torch.device | str | None = None, /, **fields: Any) -> None:
+    """Synchronize the current accelerator after ``stage`` and bracket any HIP error."""
+
+    if not _state.active:
+        return
+    start_fields = dict(fields)
+    start_fields.update(_stream_fields(device))
+    trace_stage(f"{stage}_sync_start", **start_fields)
+    try:
+        torch.cuda.synchronize(device)
+    except BaseException as exc:
+        trace_stage(
+            f"{stage}_sync_failed",
+            **fields,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+        raise
+    trace_stage(f"{stage}_sync_complete", **fields)
+
+
+def _tensor_fields(tensor: torch.Tensor) -> dict[str, Any]:
+    fields: dict[str, Any] = {
+        "shape": tuple(tensor.shape),
+        "dtype": str(tensor.dtype),
+        "device": str(tensor.device),
+        "strides": tuple(tensor.stride()),
+        "contiguous": tensor.is_contiguous(),
+        "storage_offset": tensor.storage_offset(),
+        "is_view": tensor._base is not None,
+    }
+    try:
+        fields["data_ptr"] = hex(tensor.data_ptr())
+        fields["storage_ptr"] = hex(tensor.untyped_storage().data_ptr())
+    except Exception as exc:
+        fields["pointer_info"] = f"unavailable:{type(exc).__name__}"
+    return fields
+
+
+def trace_tensor(stage: str, tensor: torch.Tensor, *, include_minmax: bool = False) -> None:
+    if not _state.active:
+        return
+    fields = _tensor_fields(tensor)
+    if include_minmax and tensor.numel() > 0:
+        if tensor.numel() > 4096:
+            fields["minmax"] = "skipped_large_tensor"
+        else:
+            # ID tensors are tiny.  Copying after the preceding explicit synchronization
+            # avoids launching advanced indexing merely to produce diagnostics.
+            cpu = tensor.detach().reshape(-1).to("cpu")
+            fields["min"] = cpu.min().item()
+            fields["max"] = cpu.max().item()
+    trace_stage(stage, **fields)
+
+
+def snapshot_cpu(tensor: torch.Tensor) -> torch.Tensor:
+    """Small diagnostic snapshot, detached and contiguous on the CPU."""
+
+    return tensor.detach().to("cpu").contiguous()
+
+
+def cache_hit_miss_counts(
+    raw_expert_ids: torch.Tensor,
+    slot_for_layer: torch.Tensor,
+    num_experts: int,
+) -> tuple[int, int, int]:
+    """Return unique active, hit, and miss counts without device-side indexing."""
+
+    raw = snapshot_cpu(raw_expert_ids).reshape(-1)
+    if raw.dtype != torch.int32:
+        raise TypeError(f"raw expert IDs must be torch.int32, got {raw.dtype}")
+    if raw.numel() == 0:
+        raise ValueError("raw expert IDs must not be empty during decode")
+    lo, hi = int(raw.min()), int(raw.max())
+    if lo < 0 or hi >= num_experts:
+        raise ValueError(f"raw expert IDs out of range: min={lo}, max={hi}, experts={num_experts}")
+    slots = snapshot_cpu(slot_for_layer).reshape(-1)
+    unique = torch.unique(raw.to(torch.int64))
+    resident = slots[unique]
+    hits = int((resident >= 0).sum())
+    active = int(unique.numel())
+    return active, hits, active - hits
+
+
+def _inspect_host_mapping(
+    cache: Any,
+    layer_id: int,
+    extension: Any | None,
+) -> _HostMappingStatus:
+    """Prove that each current host bank has a HIP-visible device mapping."""
+
+    residency = "unknown"
+    try:
+        residency = str(cache.layer_residency[layer_id])
+    except (AttributeError, IndexError, TypeError):
+        pass
+
+    bank_names = tuple(getattr(cache, "bank_schema", ()))
+    sources: list[tuple[str, torch.Tensor]] = []
+    failed_bank = "none"
+    reason = "ok"
+    for name in bank_names:
+        try:
+            source = cache.bank_sources[name][layer_id]
+        except (AttributeError, IndexError, KeyError, TypeError):
+            failed_bank = str(name)
+            reason = "host_bank_source_unavailable"
+            break
+        sources.append((str(name), source))
+
+    first_host_ptr = "unavailable"
+    if sources:
+        try:
+            first_host_ptr = hex(int(sources[0][1].data_ptr()))
+        except Exception:
+            reason = "host_pointer_unavailable"
+            failed_bank = sources[0][0]
+
+    if extension is None:
+        return _HostMappingStatus(
+            False,
+            False,
+            residency,
+            len(bank_names),
+            0,
+            first_host_ptr,
+            "unavailable",
+            failed_bank if failed_bank != "none" else (sources[0][0] if sources else "none"),
+            "pinned_extension_missing",
+        )
+
+    host_device_ptr = getattr(extension, "host_device_ptr", None)
+    if not callable(host_device_ptr):
+        return _HostMappingStatus(
+            False,
+            True,
+            residency,
+            len(bank_names),
+            0,
+            first_host_ptr,
+            "unavailable",
+            failed_bank if failed_bank != "none" else (sources[0][0] if sources else "none"),
+            "host_device_ptr_unavailable",
+        )
+
+    if reason != "ok" or len(sources) != len(bank_names) or not sources:
+        return _HostMappingStatus(
+            False,
+            True,
+            residency,
+            len(bank_names),
+            0,
+            first_host_ptr,
+            "unavailable",
+            failed_bank,
+            reason if reason != "ok" else "host_bank_source_unavailable",
+        )
+
+    mapped_bank_count = 0
+    first_device_ptr = "unavailable"
+    for name, source in sources:
+        if not isinstance(source, torch.Tensor) or source.device.type != "cpu":
+            return _HostMappingStatus(
+                False,
+                True,
+                residency,
+                len(bank_names),
+                mapped_bank_count,
+                first_host_ptr,
+                first_device_ptr,
+                name,
+                "host_bank_source_not_cpu",
+            )
+        try:
+            mapped_ptr = int(host_device_ptr(int(source.data_ptr())))
+        except Exception:
+            return _HostMappingStatus(
+                False,
+                True,
+                residency,
+                len(bank_names),
+                mapped_bank_count,
+                first_host_ptr,
+                first_device_ptr,
+                name,
+                "host_device_mapping_failed",
+            )
+        if mapped_ptr == 0:
+            return _HostMappingStatus(
+                False,
+                True,
+                residency,
+                len(bank_names),
+                mapped_bank_count,
+                first_host_ptr,
+                first_device_ptr,
+                name,
+                "host_device_pointer_zero",
+            )
+        mapped_bank_count += 1
+        if first_device_ptr == "unavailable":
+            first_device_ptr = hex(mapped_ptr)
+
+    return _HostMappingStatus(
+        True,
+        True,
+        residency,
+        len(bank_names),
+        mapped_bank_count,
+        first_host_ptr,
+        first_device_ptr,
+        "none",
+        "ok",
+    )
+
+
+def inspect_host_mapping(cache: Any, layer_id: int) -> _HostMappingStatus:
+    """Inspect current bank mappings using the packaged pinned-memory extension."""
+
+    from freetoken.kernel.pinned import _load_pinned_extension
+
+    try:
+        extension = _load_pinned_extension()
+    except Exception:
+        # Capability detection must fail closed: a broken/unloadable extension is not
+        # evidence that a Windows host VA is safe for direct GPU dereference.
+        return replace(
+            _inspect_host_mapping(cache, layer_id, None),
+            reason="pinned_extension_load_failed",
+        )
+    return _inspect_host_mapping(cache, layer_id, extension)
+
+
+def preflight_windows_rocm_host_mapping(
+    cache: Any,
+    layer_id: int,
+    *,
+    allow_unmapped_safe_copy: bool = False,
+) -> bool:
+    """Fail before a traced Windows/ROCm decode copy can dereference host memory."""
+
+    if not _state.active or sys.platform != "win32" or not getattr(torch.version, "hip", None):
+        return False
+
+    status = inspect_host_mapping(cache, layer_id)
+    trace_stage(
+        "host_mapping_preflight",
+        platform="windows",
+        rocm="true",
+        pinned_extension_loaded=str(status.pinned_extension_loaded).lower(),
+        host_bank_residency=status.host_bank_residency,
+        bank_count=status.bank_count,
+        mapped_bank_count=status.mapped_bank_count,
+        host_ptr=status.host_ptr,
+        device_ptr=status.device_ptr,
+        failed_bank=status.failed_bank,
+        safe_for_gpu_deref=str(status.safe_for_gpu_deref).lower(),
+        reason=status.reason,
+        layer=layer_id,
+        safe_copy_selected=str(allow_unmapped_safe_copy).lower(),
+    )
+    if not status.safe_for_gpu_deref and not allow_unmapped_safe_copy:
+        raise RuntimeError(
+            "Windows ROCm offload decode trace refused copy_missing because the "
+            "current host expert banks are not demonstrably pinned and HIP "
+            f"device-mapped (reason={status.reason}, bank={status.failed_bank}). "
+            "No GPU copy kernel was launched."
+        )
+    return True
+
+
+def _validate_slot_ids(slot_ids: torch.Tensor, num_cache_slots: int) -> tuple[int, int]:
+    """Pure validation used by the trace and CPU-only regression tests."""
+
+    if slot_ids.dtype != torch.int32:
+        raise TypeError(f"remapped slot IDs must be torch.int32, got {slot_ids.dtype}")
+    if not slot_ids.is_contiguous():
+        raise ValueError(f"remapped slot IDs must be contiguous, strides={slot_ids.stride()}")
+    if slot_ids.numel() == 0:
+        raise ValueError("remapped slot IDs must not be empty during decode")
+    lo, hi = int(slot_ids.min()), int(slot_ids.max())
+    if lo < 0 or hi >= num_cache_slots:
+        raise ValueError(
+            f"remapped slot IDs out of range: min={lo}, max={hi}, "
+            f"num_cache_slots={num_cache_slots}"
+        )
+    return lo, hi
+
+
+def validate_remapped_slots(
+    raw_expert_ids: torch.Tensor,
+    slot_ids: torch.Tensor,
+    id_of_slot: torch.Tensor,
+    *,
+    layer_id: int,
+    num_experts: int,
+    num_cache_slots: int,
+) -> tuple[int, int, int]:
+    """Validate slot geometry and the forward/reverse cache mapping before GEMM."""
+
+    if raw_expert_ids.dtype != torch.int32:
+        raise TypeError(f"raw expert IDs must be torch.int32, got {raw_expert_ids.dtype}")
+    if slot_ids.dtype != torch.int32:
+        raise TypeError(f"remapped slot IDs must be torch.int32, got {slot_ids.dtype}")
+    if not slot_ids.is_contiguous():
+        raise ValueError(f"remapped slot IDs must be contiguous, strides={slot_ids.stride()}")
+    raw = snapshot_cpu(raw_expert_ids)
+    slots = snapshot_cpu(slot_ids)
+    owners = snapshot_cpu(id_of_slot).reshape(-1)
+    if raw.shape != slots.shape:
+        raise ValueError(f"raw/slot shape mismatch: raw={raw.shape}, slots={slots.shape}")
+    lo, hi = _validate_slot_ids(slots, num_cache_slots)
+    flat_slots = slots.reshape(-1).to(torch.int64)
+    actual = owners[flat_slots]
+    expected = layer_id * num_experts + raw.reshape(-1).to(actual.dtype)
+    mismatched = actual != expected
+    if bool(mismatched.any()):
+        idx = int(torch.nonzero(mismatched, as_tuple=False)[0])
+        raise ValueError(
+            "cache slot is not populated by the routed expert: "
+            f"route={idx}, raw_expert={int(raw.reshape(-1)[idx])}, "
+            f"slot={int(flat_slots[idx])}, owner={int(actual[idx])}, "
+            f"expected_owner={int(expected[idx])}"
+        )
+    return lo, hi, int(torch.unique(flat_slots).numel())
+
+
+def _reset_for_tests() -> None:
+    global _state
+    _state = _TraceState()
+
+
+__all__ = [
+    "TRACE_ENV",
+    "TRACE_PREFIX",
+    "begin_first_decode",
+    "cache_hit_miss_counts",
+    "finish_trace",
+    "inspect_host_mapping",
+    "preflight_windows_rocm_host_mapping",
+    "snapshot_cpu",
+    "synchronize",
+    "trace_active",
+    "trace_enabled",
+    "trace_stage",
+    "trace_tensor",
+    "validate_remapped_slots",
+]

--- a/python/freetoken/moe/offload_cache.py
+++ b/python/freetoken/moe/offload_cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import os
+import sys
 from dataclasses import dataclass
 from typing import Iterator
 
@@ -13,6 +14,9 @@ from flashlib.kernels.slot_cache import N_STATS, Stat
 # (kept for A/B profiling). Falls back to per-bank automatically if a bank's row bytes or
 # base address are not 16-byte aligned.
 _FUSED_COPY = os.getenv("FREETOKEN_FUSED_COPY", "1").strip().lower() not in {"0", "false", "no", "off"}
+# Force/debug override only. Unmapped Windows ROCm banks select this path automatically.
+SAFE_OFFLOAD_COPY_ENV = "FREETOKEN_ROCM_SAFE_OFFLOAD_COPY"
+_ENV_TRUE = {"1", "true", "yes", "on"}
 
 # cudaMemcpyBatchAsync silently degrades to a SYNCHRONOUS copy when a batch mixes
 # large entries with sub-~256KB entries on registered host memory (H100 + CUDA 13.0,
@@ -226,6 +230,9 @@ class OffloadMoeCache:
         # machinery that moves bank bytes (copy_missing, the prefill double buffers,
         # bank_views) iterates this list, so the slot cache is bank-count agnostic.
         self.banks: list[tuple[list[torch.Tensor], torch.Tensor]] = []
+        # Lazily proven per-layer host-device mapping capability. Host sources are fixed
+        # after registration, so repeated decode steps need not call the HIP mapping API.
+        self._host_mapping_safe: list[bool | None] = [None] * self.num_layers
         # Fused multi-bank copy descriptor (built by set_bank_sources/_build_copy_plan).
         # Source pointers are per layer (_copy_src_ptrs[layer_id] -> [num_banks] device
         # tensor); dst/feat are layer-invariant.
@@ -311,6 +318,7 @@ class OffloadMoeCache:
                 device=self.device,
             )
         self.banks = [(self.bank_sources[n], self.bank_caches[n]) for n in self.bank_schema]
+        self._host_mapping_safe = [None] * self.num_layers
         self._build_copy_plan()
         if self.prefill_overlap:
             self._init_prefill_overlap_buffers()
@@ -840,6 +848,95 @@ class OffloadMoeCache:
         self.stat_active_layer[layer_id] += active
         self.stat_steps_layer[layer_id] += 1
 
+    def should_use_safe_offload_copy(self, layer_id: int) -> bool:
+        """Select staged H2D when Windows ROCm cannot safely dereference host banks."""
+
+        if sys.platform != "win32" or not getattr(torch.version, "hip", None):
+            return False
+        if os.getenv(SAFE_OFFLOAD_COPY_ENV, "").strip().lower() in _ENV_TRUE:
+            return True
+
+        from freetoken.moe.decode_trace import inspect_host_mapping
+
+        # Windows/WDDM can map registered host memory at a device address different
+        # from its CPU virtual address. A "pinned" residency label is insufficient:
+        # without a working host_device_ptr translation, fast_index_copy would hand the
+        # GPU an unregistered CPU VA and can trigger a driver TDR. Fail over to ordinary
+        # PyTorch H2D copies unless every current bank has a demonstrated HIP mapping.
+        mapping_safe = self._host_mapping_safe[layer_id]
+        if mapping_safe is None:
+            mapping_safe = inspect_host_mapping(self, layer_id).safe_for_gpu_deref
+            self._host_mapping_safe[layer_id] = mapping_safe
+        return not mapping_safe
+
+    def _safe_copy_plan(self) -> tuple[tuple[int, int], ...]:
+        """Snapshot the staged LRU destinations/source rows into a host copy plan."""
+
+        count = int(self.num_indices.item())
+        if count < 0 or count > self.num_experts:
+            raise ValueError(
+                f"invalid safe-copy row count {count}; expected 0..{self.num_experts}"
+            )
+        destinations = self.evict_slots[:count].detach().to("cpu").tolist()
+        sources = self.src_indices[:count].detach().to("cpu").tolist()
+        plan = tuple((int(dst), int(src)) for dst, src in zip(destinations, sources))
+        for destination, source in plan:
+            if destination < 0 or destination >= self.cache_size:
+                raise ValueError(
+                    f"safe-copy destination slot {destination} outside cache size {self.cache_size}"
+                )
+            if source < 0 or source >= self.num_experts:
+                raise ValueError(
+                    f"safe-copy source expert {source} outside expert count {self.num_experts}"
+                )
+        if len({destination for destination, _ in plan}) != len(plan):
+            raise ValueError("safe-copy plan contains duplicate destination slots")
+        return plan
+
+    def _copy_missing_safe(self, layer_id: int) -> None:
+        """Copy staged miss rows through ordinary synchronous PyTorch H2D copies."""
+
+        from freetoken.moe import decode_trace
+
+        plan = self._safe_copy_plan()
+        tracing = decode_trace.trace_active()
+        if tracing:
+            decode_trace.trace_stage(
+                "safe_copy_start",
+                layer=layer_id,
+                bank_count=len(self.banks),
+                missing_row_count=len(plan),
+            )
+        for bank_index, (name, (per_layer, cache)) in enumerate(
+            zip(self.bank_schema, self.banks)
+        ):
+            if tracing:
+                decode_trace.trace_stage(
+                    "safe_copy_bank_start",
+                    layer=layer_id,
+                    bank=name,
+                    bank_index=bank_index,
+                    missing_row_count=len(plan),
+                )
+            source = per_layer[layer_id]
+            for destination, source_index in plan:
+                cache[destination].copy_(source[source_index], non_blocking=False)
+            if tracing:
+                decode_trace.trace_stage(
+                    "safe_copy_bank_complete",
+                    layer=layer_id,
+                    bank=name,
+                    bank_index=bank_index,
+                    copied_row_count=len(plan),
+                )
+        if tracing:
+            decode_trace.synchronize(
+                "safe_copy",
+                self.device,
+                layer=layer_id,
+                copied_row_count=len(plan),
+            )
+
     def decode_miss_stats(self) -> dict:
         if self.decode_target == "hybrid":
             active = int(self.stat_active.item())
@@ -927,6 +1024,9 @@ class OffloadMoeCache:
         assert self.banks, "set_bank_sources must register the banks first"
         layer_id = self._pending_src_layer
         assert layer_id is not None, "no staged misses (ensure_experts/materialize_layer first)"
+        if self.should_use_safe_offload_copy(layer_id):
+            self._copy_missing_safe(layer_id)
+            return
         if self._copy_fused_ok:
             from freetoken.kernel.fast_index_copy import fast_index_copy_multi_jit
 

--- a/tests/moe/test_decode_trace.py
+++ b/tests/moe/test_decode_trace.py
@@ -1,0 +1,242 @@
+import io
+import os
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from freetoken.moe import decode_trace
+
+
+def _batch(phase: str):
+    return SimpleNamespace(phase=phase, is_decode=phase == "decode", size=1)
+
+
+def _host_cache(*sources: torch.Tensor):
+    names = tuple(f"bank_{index}" for index in range(len(sources)))
+    return SimpleNamespace(
+        bank_schema=names,
+        bank_sources={name: [source] for name, source in zip(names, sources)},
+        layer_residency=["pinned"],
+    )
+
+
+class _MappedExtension:
+    def host_device_ptr(self, host_ptr: int) -> int:
+        return host_ptr + 0x1000
+
+
+class DecodeTraceTests(unittest.TestCase):
+    def setUp(self):
+        decode_trace._reset_for_tests()
+
+    def tearDown(self):
+        decode_trace._reset_for_tests()
+
+    def test_trace_mode_is_inert_when_disabled(self):
+        output = io.StringIO()
+        with (
+            mock.patch.dict(os.environ, {decode_trace.TRACE_ENV: ""}),
+            redirect_stderr(output),
+        ):
+            self.assertFalse(decode_trace.begin_first_decode(_batch("decode")))
+            decode_trace.trace_stage("must_not_print")
+            decode_trace.synchronize("must_not_sync")
+        self.assertEqual(output.getvalue(), "")
+
+        # A disabled call does not consume the one-shot claim.
+        with (
+            mock.patch.dict(os.environ, {decode_trace.TRACE_ENV: "1"}),
+            mock.patch.object(
+                decode_trace, "_stream_fields", return_value={"stream": "test"}
+            ),
+            redirect_stderr(io.StringIO()),
+        ):
+            self.assertTrue(decode_trace.begin_first_decode(_batch("decode")))
+
+    def test_trace_claims_only_first_real_decode(self):
+        output = io.StringIO()
+        with (
+            mock.patch.dict(os.environ, {decode_trace.TRACE_ENV: "1"}),
+            mock.patch.object(
+                decode_trace, "_stream_fields", return_value={"stream": "test"}
+            ),
+            redirect_stderr(output),
+        ):
+            self.assertFalse(decode_trace.begin_first_decode(_batch("prefill")))
+            self.assertTrue(decode_trace.begin_first_decode(_batch("decode")))
+            decode_trace.finish_trace()
+            self.assertFalse(decode_trace.begin_first_decode(_batch("decode")))
+
+        rendered = output.getvalue()
+        self.assertEqual(rendered.count("stage=decode_entry"), 1)
+        self.assertEqual(rendered.count("stage=decode_trace_complete"), 1)
+
+    def test_invalid_slot_ids_are_rejected(self):
+        cases = [
+            (torch.tensor([[0, -1]], dtype=torch.int32), ValueError, "out of range"),
+            (torch.tensor([[0, 6]], dtype=torch.int32), ValueError, "out of range"),
+            (torch.tensor([[0, 1]], dtype=torch.int64), TypeError, "torch.int32"),
+            (
+                torch.arange(4, dtype=torch.int32).view(2, 2).t(),
+                ValueError,
+                "contiguous",
+            ),
+        ]
+        for slot_ids, error, message in cases:
+            with self.subTest(slot_ids=slot_ids, error=error):
+                with self.assertRaisesRegex(error, message):
+                    decode_trace._validate_slot_ids(slot_ids, num_cache_slots=6)
+
+    def test_valid_slot_ids_and_populated_owners_pass(self):
+        raw = torch.tensor([[2, 1, 2]], dtype=torch.int32)
+        slots = torch.tensor([[5, 0, 5]], dtype=torch.int32)
+        owners = torch.full((6,), -1, dtype=torch.int32)
+        owners[0] = 1
+        owners[5] = 2
+
+        self.assertEqual(decode_trace._validate_slot_ids(slots, 6), (0, 5))
+        self.assertEqual(
+            decode_trace.validate_remapped_slots(
+                raw,
+                slots,
+                owners,
+                layer_id=0,
+                num_experts=4,
+                num_cache_slots=6,
+            ),
+            (0, 5, 2),
+        )
+
+    def test_stale_or_wrong_layer_slot_owner_is_rejected(self):
+        raw = torch.tensor([[2, 1]], dtype=torch.int32)
+        slots = torch.tensor([[5, 0]], dtype=torch.int32)
+        owners = torch.full((6,), -1, dtype=torch.int32)
+        owners[0] = 1
+        owners[5] = 6  # layer 1 / expert 2, not layer 0 / expert 2
+
+        with self.assertRaisesRegex(ValueError, "not populated by the routed expert"):
+            decode_trace.validate_remapped_slots(
+                raw,
+                slots,
+                owners,
+                layer_id=0,
+                num_experts=4,
+                num_cache_slots=6,
+            )
+
+    def test_disabled_debug_path_never_synchronizes_nvidia_or_rocm(self):
+        calls = []
+        with (
+            mock.patch.dict(os.environ, {decode_trace.TRACE_ENV: ""}),
+            mock.patch.object(torch.cuda, "synchronize", side_effect=calls.append),
+        ):
+            decode_trace.synchronize("disabled", torch.device("cuda"))
+
+        self.assertEqual(calls, [])
+
+    def test_host_mapping_preflight_extension_missing_is_unsafe(self):
+        cache = _host_cache(torch.empty(4, dtype=torch.uint8))
+        output = io.StringIO()
+        with (
+            mock.patch.dict(os.environ, {decode_trace.TRACE_ENV: "1"}),
+            mock.patch.object(decode_trace, "_stream_fields", return_value={"stream": "test"}),
+            mock.patch.object(decode_trace.sys, "platform", "win32"),
+            mock.patch.object(torch.version, "hip", "test-rocm"),
+            mock.patch("freetoken.kernel.pinned._load_pinned_extension", return_value=None),
+            redirect_stderr(output),
+        ):
+            self.assertTrue(decode_trace.begin_first_decode(_batch("decode")))
+            with self.assertRaisesRegex(RuntimeError, "pinned_extension_missing"):
+                decode_trace.preflight_windows_rocm_host_mapping(cache, 0)
+
+        marker = next(
+            line for line in output.getvalue().splitlines() if "stage=host_mapping_preflight" in line
+        )
+        self.assertIn("pinned_extension_loaded=false", marker)
+        self.assertIn("device_ptr=unavailable", marker)
+        self.assertIn("safe_for_gpu_deref=false", marker)
+        self.assertIn("reason=pinned_extension_missing", marker)
+
+    def test_host_mapping_preflight_unavailable_mapping_is_unsafe(self):
+        cache = _host_cache(torch.empty(4, dtype=torch.uint8))
+        extension = mock.Mock()
+        extension.host_device_ptr.side_effect = RuntimeError("not registered")
+        output = io.StringIO()
+        with (
+            mock.patch.dict(os.environ, {decode_trace.TRACE_ENV: "1"}),
+            mock.patch.object(decode_trace, "_stream_fields", return_value={"stream": "test"}),
+            mock.patch.object(decode_trace.sys, "platform", "win32"),
+            mock.patch.object(torch.version, "hip", "test-rocm"),
+            mock.patch(
+                "freetoken.kernel.pinned._load_pinned_extension", return_value=extension
+            ),
+            redirect_stderr(output),
+        ):
+            self.assertTrue(decode_trace.begin_first_decode(_batch("decode")))
+            with self.assertRaisesRegex(RuntimeError, "host_device_mapping_failed"):
+                decode_trace.preflight_windows_rocm_host_mapping(cache, 0)
+
+        marker = next(
+            line for line in output.getvalue().splitlines() if "stage=host_mapping_preflight" in line
+        )
+        self.assertIn("pinned_extension_loaded=true", marker)
+        self.assertIn("mapped_bank_count=0", marker)
+        self.assertIn("safe_for_gpu_deref=false", marker)
+        self.assertIn("reason=host_device_mapping_failed", marker)
+
+    def test_host_mapping_preflight_valid_mapped_sources_are_safe(self):
+        sources = (
+            torch.empty(4, dtype=torch.uint8),
+            torch.empty(8, dtype=torch.uint8),
+        )
+        cache = _host_cache(*sources)
+        output = io.StringIO()
+        with (
+            mock.patch.dict(os.environ, {decode_trace.TRACE_ENV: "1"}),
+            mock.patch.object(decode_trace, "_stream_fields", return_value={"stream": "test"}),
+            mock.patch.object(decode_trace.sys, "platform", "win32"),
+            mock.patch.object(torch.version, "hip", "test-rocm"),
+            mock.patch(
+                "freetoken.kernel.pinned._load_pinned_extension",
+                return_value=_MappedExtension(),
+            ),
+            redirect_stderr(output),
+        ):
+            self.assertTrue(decode_trace.begin_first_decode(_batch("decode")))
+            self.assertTrue(decode_trace.preflight_windows_rocm_host_mapping(cache, 0))
+
+        marker = next(
+            line for line in output.getvalue().splitlines() if "stage=host_mapping_preflight" in line
+        )
+        self.assertIn("bank_count=2", marker)
+        self.assertIn("mapped_bank_count=2", marker)
+        self.assertIn(f"host_ptr={hex(sources[0].data_ptr())}", marker)
+        self.assertIn(f"device_ptr={hex(sources[0].data_ptr() + 0x1000)}", marker)
+        self.assertIn("safe_for_gpu_deref=true", marker)
+        self.assertIn("reason=ok", marker)
+
+    def test_host_mapping_preflight_is_inert_when_trace_disabled(self):
+        output = io.StringIO()
+        with (
+            mock.patch.dict(os.environ, {decode_trace.TRACE_ENV: ""}),
+            mock.patch.object(decode_trace.sys, "platform", "win32"),
+            mock.patch.object(torch.version, "hip", "test-rocm"),
+            mock.patch(
+                "freetoken.kernel.pinned._load_pinned_extension",
+                side_effect=AssertionError("extension loader must remain untouched"),
+            ) as loader,
+            redirect_stderr(output),
+        ):
+            self.assertFalse(
+                decode_trace.preflight_windows_rocm_host_mapping(object(), layer_id=0)
+            )
+
+        loader.assert_not_called()
+        self.assertEqual(output.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/moe/test_safe_offload_copy.py
+++ b/tests/moe/test_safe_offload_copy.py
@@ -1,0 +1,210 @@
+import io
+import os
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from freetoken.moe import decode_trace
+from freetoken.moe.offload_cache import SAFE_OFFLOAD_COPY_ENV, OffloadMoeCache
+
+
+class _MappedExtension:
+    def host_device_ptr(self, host_ptr: int) -> int:
+        return host_ptr + 0x1000
+
+
+def _cache() -> OffloadMoeCache:
+    cache = OffloadMoeCache(
+        num_layers=1,
+        num_experts=4,
+        cache_size=6,
+        device=torch.device("cpu"),
+    )
+    gate_up = torch.stack(
+        [torch.full((2, 3), expert + 1, dtype=torch.float32) for expert in range(4)]
+    )
+    down = torch.stack(
+        [torch.full((3, 2), 10 + expert, dtype=torch.float32) for expert in range(4)]
+    )
+    cache.set_bank_sources({"gate_up": [gate_up], "down": [down]})
+    cache._pending_src_layer = 0
+    return cache
+
+
+def _batch():
+    return SimpleNamespace(phase="decode", is_decode=True, size=1)
+
+
+class SafeOffloadCopyTests(unittest.TestCase):
+    def setUp(self):
+        decode_trace._reset_for_tests()
+
+    def tearDown(self):
+        decode_trace._reset_for_tests()
+
+    def test_unmapped_windows_rocm_selects_fallback_automatically(self):
+        cache = _cache()
+        with (
+            mock.patch.dict(os.environ, {SAFE_OFFLOAD_COPY_ENV: ""}),
+            mock.patch("freetoken.moe.offload_cache.sys.platform", "win32"),
+            mock.patch.object(torch.version, "hip", "test-rocm"),
+            mock.patch("freetoken.kernel.pinned._load_pinned_extension", return_value=None),
+        ):
+            self.assertTrue(cache.should_use_safe_offload_copy(0))
+
+    def test_unloadable_mapping_extension_fails_closed_to_safe_copy(self):
+        cache = _cache()
+        with (
+            mock.patch.dict(os.environ, {SAFE_OFFLOAD_COPY_ENV: ""}),
+            mock.patch("freetoken.moe.offload_cache.sys.platform", "win32"),
+            mock.patch.object(torch.version, "hip", "test-rocm"),
+            mock.patch(
+                "freetoken.kernel.pinned._load_pinned_extension",
+                side_effect=OSError("extension dependency unavailable"),
+            ),
+        ):
+            self.assertTrue(cache.should_use_safe_offload_copy(0))
+
+    def test_mapped_windows_rocm_keeps_existing_fast_path(self):
+        cache = _cache()
+        with (
+            mock.patch.dict(os.environ, {SAFE_OFFLOAD_COPY_ENV: ""}),
+            mock.patch("freetoken.moe.offload_cache.sys.platform", "win32"),
+            mock.patch.object(torch.version, "hip", "test-rocm"),
+            mock.patch(
+                "freetoken.kernel.pinned._load_pinned_extension",
+                return_value=_MappedExtension(),
+            ),
+            mock.patch.object(cache, "_copy_missing_safe") as safe_copy,
+            mock.patch("freetoken.kernel.fast_index_copy_jit") as fast_copy,
+        ):
+            self.assertFalse(cache.should_use_safe_offload_copy(0))
+            cache.copy_missing()
+
+        safe_copy.assert_not_called()
+        self.assertEqual(fast_copy.call_count, len(cache.banks))
+
+    def test_force_override_selects_safe_copy_for_mapped_windows_rocm(self):
+        cache = _cache()
+        with (
+            mock.patch.dict(os.environ, {SAFE_OFFLOAD_COPY_ENV: "1"}),
+            mock.patch("freetoken.moe.offload_cache.sys.platform", "win32"),
+            mock.patch.object(torch.version, "hip", "test-rocm"),
+            mock.patch(
+                "freetoken.kernel.pinned._load_pinned_extension",
+                side_effect=AssertionError("force override must not inspect mapping"),
+            ) as loader,
+        ):
+            self.assertTrue(cache.should_use_safe_offload_copy(0))
+        loader.assert_not_called()
+
+    def test_nvidia_keeps_existing_fast_path(self):
+        cache = _cache()
+        with (
+            mock.patch.dict(os.environ, {SAFE_OFFLOAD_COPY_ENV: "1"}),
+            mock.patch("freetoken.moe.offload_cache.sys.platform", "win32"),
+            mock.patch.object(torch.version, "hip", None),
+        ):
+            self.assertFalse(cache.should_use_safe_offload_copy(0))
+
+    def test_copy_missing_bypasses_fast_kernels_for_unsafe_windows_rocm(self):
+        cache = _cache()
+        cache._copy_fused_ok = True
+        with (
+            mock.patch.dict(os.environ, {SAFE_OFFLOAD_COPY_ENV: ""}),
+            mock.patch("freetoken.moe.offload_cache.sys.platform", "win32"),
+            mock.patch.object(torch.version, "hip", "test-rocm"),
+            mock.patch("freetoken.kernel.pinned._load_pinned_extension", return_value=None),
+            mock.patch.object(cache, "_copy_missing_safe") as safe_copy,
+        ):
+            cache.copy_missing()
+
+        safe_copy.assert_called_once_with(0)
+
+    def test_copy_missing_keeps_nvidia_per_bank_path(self):
+        cache = _cache()
+        with (
+            mock.patch.dict(os.environ, {SAFE_OFFLOAD_COPY_ENV: "1"}),
+            mock.patch("freetoken.moe.offload_cache.sys.platform", "win32"),
+            mock.patch.object(torch.version, "hip", None),
+            mock.patch.object(cache, "_copy_missing_safe") as safe_copy,
+            mock.patch("freetoken.kernel.fast_index_copy_jit") as fast_copy,
+        ):
+            cache.copy_missing()
+
+        safe_copy.assert_not_called()
+        self.assertEqual(fast_copy.call_count, len(cache.banks))
+
+    def test_safe_copy_plan_preserves_staged_lru_pairs(self):
+        cache = _cache()
+        cache.num_indices.fill_(3)
+        cache.evict_slots[:3] = torch.tensor([5, 1, 4], dtype=torch.int32)
+        cache.src_indices[:3] = torch.tensor([2, 0, 3], dtype=torch.int32)
+
+        self.assertEqual(cache._safe_copy_plan(), ((5, 2), (1, 0), (4, 3)))
+
+    def test_safe_copy_preserves_lru_slot_and_remap_semantics(self):
+        cache = _cache()
+        cache.num_indices.fill_(2)
+        cache.evict_slots[:2] = torch.tensor([4, 1], dtype=torch.int32)
+        cache.src_indices[:2] = torch.tensor([3, 0], dtype=torch.int32)
+        cache.slot_for_id[0, 3] = 4
+        cache.slot_for_id[0, 0] = 1
+        cache.id_of_slot[4] = 3
+        cache.id_of_slot[1] = 0
+        slot_for_id_before = cache.slot_for_id.clone()
+        id_of_slot_before = cache.id_of_slot.clone()
+        for _, destination in cache.banks:
+            destination.zero_()
+
+        output = io.StringIO()
+        with (
+            mock.patch.dict(os.environ, {decode_trace.TRACE_ENV: "1"}),
+            mock.patch.object(decode_trace, "_stream_fields", return_value={"stream": "test"}),
+            mock.patch.object(torch.cuda, "synchronize") as synchronize,
+            redirect_stderr(output),
+        ):
+            self.assertTrue(decode_trace.begin_first_decode(_batch()))
+            cache._copy_missing_safe(0)
+
+        synchronize.assert_called_once_with(cache.device)
+        torch.testing.assert_close(cache.slot_for_id, slot_for_id_before)
+        torch.testing.assert_close(cache.id_of_slot, id_of_slot_before)
+        for per_layer, destination in cache.banks:
+            source = per_layer[0]
+            torch.testing.assert_close(destination[4], source[3])
+            torch.testing.assert_close(destination[1], source[0])
+            self.assertEqual(int(torch.count_nonzero(destination[[0, 2, 3, 5]])), 0)
+
+        rendered = output.getvalue()
+        self.assertIn("stage=safe_copy_start", rendered)
+        self.assertEqual(rendered.count("stage=safe_copy_bank_start"), 2)
+        self.assertEqual(rendered.count("stage=safe_copy_bank_complete"), 2)
+        self.assertIn("stage=safe_copy_sync_complete", rendered)
+
+    def test_tracing_disabled_has_no_markers_or_debug_synchronization(self):
+        cache = _cache()
+        cache.num_indices.fill_(1)
+        cache.evict_slots[0] = 2
+        cache.src_indices[0] = 1
+        output = io.StringIO()
+        with (
+            mock.patch.dict(os.environ, {decode_trace.TRACE_ENV: ""}),
+            mock.patch.object(decode_trace, "trace_stage") as trace_stage,
+            mock.patch.object(decode_trace, "synchronize") as trace_synchronize,
+            mock.patch.object(torch.cuda, "synchronize") as cuda_synchronize,
+            redirect_stderr(output),
+        ):
+            cache._copy_missing_safe(0)
+
+        trace_stage.assert_not_called()
+        trace_synchronize.assert_not_called()
+        cuda_synchronize.assert_not_called()
+        self.assertEqual(output.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a capability-gated Windows ROCm fallback for MoE offload cache misses when host expert banks do not have demonstrable HIP device mappings.

## Problem

On Windows ROCm, FreeToken could label expert-bank storage as pinned even when the packaged `_pinned_tensor` extension was unavailable and no valid mapped device pointer existed.

Model loading and prefill succeeded, but the first real autoregressive decode step entered the fast offload-copy path with host memory that was unsafe for direct GPU dereference. On an RX 9070 XT this caused an AMD driver TDR and a subsequent asynchronous HIP launch failure.

Replacing the MXFP4 split-K decode GEMM with the grouped/prefill GEMM did not fix the crash.

## Root cause

Windows/WDDM does not guarantee that registered host memory is GPU-visible at its CPU virtual address. The existing fallback could use a raw host `data_ptr()` when `_pinned_tensor` and its `host_device_ptr` translation were unavailable.

A `pinned` residency label alone was therefore not sufficient evidence for direct GPU access.

## Fix

For Windows ROCm:

1. Inspect every host bank for the current layer using the packaged pinned-memory capability.
2. Retain the existing fast-copy path only if every source has a valid, nonzero mapped device pointer.
3. Otherwise, copy only the staged missing expert rows with ordinary blocking PyTorch H2D copies into the existing GPU cache slots.
4. Cache the mapping decision per layer because host-bank allocations remain fixed.

The fallback consumes the existing `num_indices`, `evict_slots`, and `src_indices` plan. It does not modify LRU eviction, slot ownership, expert remapping, or cache allocation.

`FREETOKEN_ROCM_SAFE_OFFLOAD_COPY=1` remains available as a Windows ROCm force-safe/debug override but is not required.

## Scope / platform gating

- Automatic fallback requires Windows and `torch.version.hip`.
- NVIDIA/CUDA dispatch is unchanged.
- Windows ROCm with valid mapped host banks retains the existing fused/per-bank fast path.
- Mapping capability detection fails closed to safe copy.
- Decode tracing remains disabled unless explicitly enabled.
- No CUDA graph behavior is enabled or changed.

## Validation

CPU-only regression suite:

- 20 tests passed.
- Covers unmapped Windows ROCm automatic selection, extension-load failure, valid mapped-host fast dispatch, NVIDIA fast dispatch, force-safe override, bypass of both unsafe fast-copy implementations, copy-plan preservation, LRU slot/remap preservation, and trace-disabled inertness.
- All nine modified/new Python files pass `py_compile`.
- `git diff --check` passes.

Real hardware:

- Windows 11 Pro build 26200
- AMD Radeon RX 9070 XT (`gfx1201`)
- Ryzen 5 7500F
- `openai/gpt-oss-20b`
- `--moe-backend offload`
- `--num-pages 2048`
- `--cuda-graph-max-bs 0`

Correctness:

- two independent 16-token requests passed;
- one automatic/no-trace/no-force-safe 64-token request passed;
- two automatic/no-trace/no-force-safe 256-token requests passed;
- no TDR;
- backend remained serving;
- 768-slot / 9.5 GiB MoE LRU cache remained active.

Performance:

| Request | Elapsed | Approx. wall-clock throughput |
|---|---:|---:|
| First 256-token request | 15.941 s | 16.1 tok/s |
| Second 256-token request, same server | 11.072 s | 23.1 tok/s |

The second result is consistent with warm-up/cache reuse, but the prompts differ, so this should not be presented as a controlled cache-hit comparison. Wall-clock throughput also includes frontend, sampling, request, and first-token prefill overhead.

## Performance note

This patch prioritizes correctness. The fallback uses individual PyTorch H2D row copies and may be slower than direct mapped-host gathering.

## Future work

Implement proper HIP host registration and mapped-device-pointer support for Windows in a separate optimization.